### PR TITLE
models/openai: support baseURL property

### DIFF
--- a/src/models/openai-legacy.ts
+++ b/src/models/openai-legacy.ts
@@ -61,6 +61,8 @@ export class OpenAILegacyChatApi implements CompletionApi {
         ? `${config.azureEndpoint}${
             config.azureEndpoint?.at(-1) === '/' ? '' : '/'
           }openai/deployments/${config.azureDeployment}`
+        : config.baseURL
+        ? config.baseURL
         : undefined,
       defaultHeaders: this._isAzure
         ? { 'api-key': String(config.apiKey) }

--- a/src/models/openai.ts
+++ b/src/models/openai.ts
@@ -61,6 +61,8 @@ export class OpenAIChatApi implements CompletionApi {
         ? `${config.azureEndpoint}${
             config.azureEndpoint?.at(-1) === '/' ? '' : '/'
           }openai/deployments/${config.azureDeployment}`
+        : config.baseURL
+        ? config.baseURL
         : undefined,
       defaultHeaders: this._isAzure
         ? { 'api-key': String(config.apiKey) }


### PR DESCRIPTION
Other LLM products sometimes aim for OpenAI API compatibility. In these cases, invisibly ignoring the baseURL property is not ideal. We add an ugly, second ternary here to fallback the passthrough baseURL.

Outside the scope of this PR, there are some pre-existing type errors on main that prohibit further versions from being built.